### PR TITLE
release workflow に渡すtokenを強くした

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
   notification:
     name: notification
     if: always()

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,5 +19,4 @@ archives:
   -
     format: zip
 release:
-  github:
   prerelease: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,4 +19,5 @@ archives:
   -
     format: zip
 release:
+  github:
   prerelease: auto


### PR DESCRIPTION
他からのhookで動いているため、tokenの権限が足りないかもしれないと考えたため