### PR TITLE
speed up pull request and push CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,8 @@ jobs:
     name: build
     strategy:
       matrix:
-        go-version: ["1.14"]  # release時には 1.10 ~ 1.15 で確かめる
-        os: [ubuntu-latest, macos-latest]
+        go-version: ["1.14"]
+        os: [ubuntu-latest]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
@@ -27,8 +27,8 @@ jobs:
     name: test
     strategy:
       matrix:
-        go-version: ["1.14"]  # release時には 1.10~1.15で確かめる
-        os: [ubuntu-latest, macos-latest]
+        go-version: ["1.14"]
+        os: [ubuntu-latest]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# Description

Now CI takes 2~3 minutes.
As long as see [CI log](https://github.com/yuchiki/atcoderHelper/actions/runs/537310803), build and test for macos are slow and others are not so slow.
In order to speed up CI, I disable CI in the macOS.

In release, build and test are still checked.

Close #

Associated #

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [x] Improve CI/CD
- [ ] Docs Modification
- [ ] Refactoring

# How This has been Tested

- [x] passed the CI lint.
- [x] passed the CI test.

# Checklist

- [x] The code is linted. (automatically)
- [x] The code is unit-tested. (automatically)
<!-- - [ ] The code is integrated-tested. (not yet implemented.) -->
- [x] Added needed tests. (or it does not need any additional tests.)
- [x] made corresponding changes to the documentation. (or it does not need any doc's changes.)
