### PR TITLE
Create contest with default template

### DIFF
--- a/internal/cmd/ach/ach.go
+++ b/internal/cmd/ach/ach.go
@@ -2,6 +2,7 @@ package ach
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/yuchiki/atcoderHelper/internal/cmd/ach/contest"
 	"github.com/yuchiki/atcoderHelper/internal/cmd/ach/version"
 )
 
@@ -19,6 +20,7 @@ func NewAchCmd() *cobra.Command {
 
 func registerSubcommands(cmd *cobra.Command) {
 	cmd.AddCommand(version.NewVersionCmd())
+	cmd.AddCommand(contest.NewContestCmd())
 }
 
 /*

--- a/internal/cmd/ach/contest/contest.go
+++ b/internal/cmd/ach/contest/contest.go
@@ -1,0 +1,22 @@
+package contest
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/yuchiki/atcoderHelper/internal/cmd/ach/contest/create"
+)
+
+func NewContestCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "contest",
+		Short: "manipulates an AtCoder contest",
+		Long:  `manipulates an AtCoder contest.`,
+	}
+
+	registerSubcommands(cmd)
+
+	return cmd
+}
+
+func registerSubcommands(cmd *cobra.Command) {
+	cmd.AddCommand(create.NewContestCreateCmd())
+}

--- a/internal/cmd/ach/contest/contest_test.go
+++ b/internal/cmd/ach/contest/contest_test.go
@@ -1,4 +1,4 @@
-package ach
+package contest
 
 import (
 	"testing"
@@ -8,9 +8,9 @@ import (
 
 func TestAch_Execute(t *testing.T) {
 	testutil.TestCaseTemplates{
-		testutil.HasName("ach"),
-		testutil.HasSubcommands("version", "contest"),
+		testutil.HasName("contest"),
+		testutil.HasSubcommands("create"),
 	}.
-		Build(NewAchCmd).
+		Build(NewContestCmd).
 		Run(t)
 }

--- a/internal/cmd/ach/contest/create/create.go
+++ b/internal/cmd/ach/contest/create/create.go
@@ -1,0 +1,37 @@
+package create
+
+import (
+	"os/exec"
+	"path"
+
+	"github.com/spf13/cobra"
+)
+
+func NewContestCreateCmd() *cobra.Command {
+	taskNames := []string{"A", "B", "C", "D", "E", "F"}
+
+	templateDir := new(string)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "show version",
+		Long:  "show version.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			contestName := args[0]
+
+			exec.Command("mkdir", contestName).Run()
+			for _, taskName := range taskNames {
+				taskDirName := path.Join(contestName, taskName)
+				exec.Command("cp", "-r", *templateDir, taskDirName).Run()
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(templateDir, "templateDir", "t", "", "contest template")
+	cmd.MarkFlagRequired("templateDir")
+
+	return cmd
+}

--- a/internal/cmd/ach/contest/create/create.go
+++ b/internal/cmd/ach/contest/create/create.go
@@ -1,6 +1,7 @@
 package create
 
 import (
+	"log"
 	"os/exec"
 	"os/user"
 	"path"
@@ -8,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// NewContestCreateCmd returns a new contest create command.
 func NewContestCreateCmd() *cobra.Command {
 	user, _ := user.Current()
 	templateDirName := path.Join(user.HomeDir, "projects", "private", "atcoder", "D")
@@ -16,16 +18,24 @@ func NewContestCreateCmd() *cobra.Command {
 	useDefaultTemplate := new(bool)
 
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "show version",
-		Long:  "show version.",
+		Use:   "create [contestName]",
+		Short: "creates contest directory",
+		Long:  "creates contest directory.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			contestName := args[0]
-			exec.Command("mkdir", contestName).Run()
+			err := exec.Command("mkdir", contestName).Run()
+			if err != nil {
+				return err
+			}
+
 			for _, taskName := range taskNames {
 				taskDirName := path.Join(contestName, taskName)
-				exec.Command("cp", "-r", templateDirName, taskDirName).Run()
+
+				err := exec.Command("cp", "-r", templateDirName, taskDirName).Run()
+				if err != nil {
+					return err
+				}
 			}
 
 			return nil
@@ -33,7 +43,10 @@ func NewContestCreateCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(useDefaultTemplate, "default-template", "d", false, "use default contest template")
-	cmd.MarkFlagRequired("default-template")
+
+	if cmd.MarkFlagRequired("default-template") != nil {
+		log.Fatal("default-template require")
+	}
 
 	return cmd
 }

--- a/internal/cmd/ach/contest/create/create.go
+++ b/internal/cmd/ach/contest/create/create.go
@@ -2,15 +2,18 @@ package create
 
 import (
 	"os/exec"
+	"os/user"
 	"path"
 
 	"github.com/spf13/cobra"
 )
 
 func NewContestCreateCmd() *cobra.Command {
+	user, _ := user.Current()
+	templateDirName := path.Join(user.HomeDir, "projects", "private", "atcoder", "D")
 	taskNames := []string{"A", "B", "C", "D", "E", "F"}
 
-	templateDir := new(string)
+	useDefaultTemplate := new(bool)
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -19,19 +22,18 @@ func NewContestCreateCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			contestName := args[0]
-
 			exec.Command("mkdir", contestName).Run()
 			for _, taskName := range taskNames {
 				taskDirName := path.Join(contestName, taskName)
-				exec.Command("cp", "-r", *templateDir, taskDirName).Run()
+				exec.Command("cp", "-r", templateDirName, taskDirName).Run()
 			}
 
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVarP(templateDir, "templateDir", "t", "", "contest template")
-	cmd.MarkFlagRequired("templateDir")
+	cmd.Flags().BoolVarP(useDefaultTemplate, "default-template", "d", false, "use default contest template")
+	cmd.MarkFlagRequired("default-template")
 
 	return cmd
 }

--- a/internal/cmd/ach/contest/create/create_test.go
+++ b/internal/cmd/ach/contest/create/create_test.go
@@ -1,0 +1,16 @@
+package create
+
+import (
+	"testing"
+
+	"github.com/yuchiki/atcoderHelper/internal/testutil"
+)
+
+func TestCreate_Execute(t *testing.T) {
+	testutil.TestCaseTemplates{
+		testutil.HasName("create"),
+		// This is a temporal implementation with temporal args, so the test are given later.
+	}.
+		Build(NewContestCreateCmd).
+		Run(t)
+}


### PR DESCRIPTION
# Description

add `ach contest create --default-template` command

This is a temproary implementation.
Used template file is hardcoded and it works only on my PC.
 
Close #52 

Associated #

## Type of Change

- [x] New Feature

# How This has been Tested

- [x] passed the CI lint.
- [x] passed the CI test.

# Checklist

- [x] The code is linted. (automatically)
- [x] The code is unit-tested. (automatically)
<!-- - [ ] The code is integrated-tested. (not yet implemented.) -->
- [x] Added needed tests. (or it does not need any additional tests.)
- [x] made corresponding changes to the documentation. (or it does not need any doc's changes.)
