### PR TITLE
make ach test command use configs

### DIFF
--- a/internal/cmd/ach/ach.go
+++ b/internal/cmd/ach/ach.go
@@ -1,6 +1,7 @@
 package ach
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path"
@@ -50,8 +51,11 @@ func initConfig() {
 }
 
 func readAppConfig() {
+	var configFileName string
+
 	if cfgFile != "" {
 		viper.SetConfigName(cfgFile)
+		configFileName = cfgFile
 	} else {
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -60,30 +64,36 @@ func readAppConfig() {
 
 		viper.AddConfigPath(path.Join(home, ".ach"))
 		viper.SetConfigName("config")
+		configFileName = "config"
 	}
 
 	if err := viper.ReadInConfig(); err != nil {
-		log.Fatal(err)
+		log.Fatal(fmt.Errorf("failed to read app config %s: %w", configFileName, err))
 	}
 
 	if err := viper.UnmarshalExact(&config.GlobalAppConfig); err != nil {
-		log.Fatal(err)
+		log.Fatal(fmt.Errorf("failed to parse app config %s: %w", configFileName, err))
 	}
 }
 
 func readTaskConfig() {
+	var configFileName string
+
 	if taskCfgFile != "" {
-		viper.SetConfigFile(cfgFile)
+		viper.SetConfigFile(taskCfgFile)
+
+		configFileName = cfgFile
 	} else {
 		viper.AddConfigPath(".")
 		viper.SetConfigName("achTaskConfig")
+		configFileName = "achTaskConfig"
 	}
 
 	if err := viper.ReadInConfig(); err != nil {
-		log.Print(err)
+		log.Print(fmt.Errorf("failed to read task config %s: %w", configFileName, err))
 	}
 
 	if err := viper.UnmarshalExact(&config.GlobalTaskConfig); err != nil {
-		log.Fatal(err)
+		log.Fatal(fmt.Errorf("failed to parse app config %s: %w", configFileName, err))
 	}
 }


### PR DESCRIPTION
# Description

build and run are designated in the manner what the ach config and the task config say. 

Close #49 

Associated #

## Type of Change

- [x] New Feature

# How This has been Tested

- [x] passed the CI lint.
- [x] passed the CI test.

# Checklist

- [x] The code is linted. (automatically)
- [x] The code is unit-tested. (automatically)
<!-- - [ ] The code is integrated-tested. (not yet implemented.) -->
- [ ] Added needed tests. (or it does not need any additional tests.) 
It is a little bit tiring task. So I made an issue #64 instead of making tests for test command.

- [x] made corresponding changes to the documentation. (or it does not need any doc's changes.)
