### PR TITLE
add recent subcommand to ach contest subcommand

### DIFF
--- a/docs/cmd/ach_contest.md
+++ b/docs/cmd/ach_contest.md
@@ -24,4 +24,5 @@ manipulates an AtCoder contest.
 * [ach](ach.md)	 - ach automates routine work you does when you participate AtCoder contests
 * [ach contest create](ach_contest_create.md)	 - creates contest directory
 * [ach contest incoming](ach_contest_incoming.md)	 - show incoming contests
+* [ach contest recent](ach_contest_recent.md)	 - show recent contests
 

--- a/docs/cmd/ach_contest_recent.md
+++ b/docs/cmd/ach_contest_recent.md
@@ -1,0 +1,29 @@
+## ach contest recent
+
+show recent contests
+
+### Synopsis
+
+show recent contests.
+
+```
+ach contest recent [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for recent
+```
+
+### Options inherited from parent commands
+
+```
+      --config string        config file (default "$HOME/.ach/config.yaml")
+      --task-config string   task config file (default "./achTaskConfig.yaml")
+```
+
+### SEE ALSO
+
+* [ach contest](ach_contest.md)	 - manipulates an AtCoder contest
+

--- a/integration/integration.sh
+++ b/integration/integration.sh
@@ -7,6 +7,9 @@ cd work
 # show incoming contests
 ach contest incoming
 
+# show recent contests
+ach contest recent
+
 # create a contest working directory
 ach contest create --default-template contestFoo
 

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -eux
 
-imageId=$(docker build -q .)
-docker run "$imageId"
+docker build -t ach_integration_test:latest .
+docker run ach_integration_test:latest

--- a/internal/cmd/ach/contest/contest.go
+++ b/internal/cmd/ach/contest/contest.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/yuchiki/atcoderHelper/internal/cmd/ach/contest/create"
 	"github.com/yuchiki/atcoderHelper/internal/cmd/ach/contest/incoming"
+	"github.com/yuchiki/atcoderHelper/internal/cmd/ach/contest/recent"
 	"github.com/yuchiki/atcoderHelper/internal/repository"
 )
 
@@ -22,4 +23,5 @@ func NewContestCmd() *cobra.Command {
 func registerSubcommands(cmd *cobra.Command) {
 	cmd.AddCommand(create.NewContestCreateCmd())
 	cmd.AddCommand(incoming.NewContestIncomingCmd(repository.FetchIncoming))
+	cmd.AddCommand(recent.NewContestRecentCmd(repository.FetchRecent))
 }

--- a/internal/cmd/ach/contest/contest_test.go
+++ b/internal/cmd/ach/contest/contest_test.go
@@ -9,8 +9,7 @@ import (
 func TestAch_Execute(t *testing.T) {
 	testutil.TestCaseTemplates{
 		testutil.HasName("contest"),
-		testutil.HasSubcommands("create"),
-		testutil.HasSubcommands("incoming"),
+		testutil.HasSubcommands("create", "incoming", "recent"),
 	}.
 		Build(NewContestCmd).
 		Run(t)

--- a/internal/cmd/ach/contest/create/create.go
+++ b/internal/cmd/ach/contest/create/create.go
@@ -112,7 +112,7 @@ func initializeTaskDirectory(absTemplateDir, contestName, taskName string) error
 
 	sampleDirName := path.Join(taskDirName, "sampleCases")
 
-	err = createSampleCases(sampleDirName, 5)
+	err = createSampleCases(sampleDirName, 5) //nolint:gomnd
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/ach/contest/recent/recent.go
+++ b/internal/cmd/ach/contest/recent/recent.go
@@ -1,0 +1,29 @@
+package recent
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/yuchiki/atcoderHelper/internal/repository"
+)
+
+func NewContestRecentCmd(fetcher func() ([]repository.ContestInfo, error)) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "recent",
+		Short: "show recent contests",
+		Long:  "show recent contests.",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			contests, err := fetcher()
+			if err != nil {
+				return err
+			}
+
+			for _, contest := range contests {
+				cmd.Printf("%v: %v\n", contest.ID, contest.Name)
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/ach/contest/recent/recent_test.go
+++ b/internal/cmd/ach/contest/recent/recent_test.go
@@ -1,0 +1,43 @@
+package recent
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/yuchiki/atcoderHelper/internal/repository"
+	"github.com/yuchiki/atcoderHelper/internal/testutil"
+)
+
+var errUnknownInRepositoryLayer = errors.New("an error thrown in fetcher function")
+
+func TestRecent_Execute(t *testing.T) {
+	generateBuilder := func(infos []repository.ContestInfo, err error) func() *cobra.Command {
+		return func() *cobra.Command {
+			return NewContestRecentCmd(func() ([]repository.ContestInfo, error) {
+				return infos, err
+			})
+		}
+	}
+
+	testutil.TestCaseTemplates{
+		testutil.HasName("recent"),
+	}.Build(generateBuilder(nil, nil)).Run(t)
+
+	testutil.TestCases{
+		{
+			Name: "OK",
+			CmdBuilder: generateBuilder([]repository.ContestInfo{
+				{ID: "id1", Name: "name1"},
+				{ID: "id2", Name: "name2"},
+				{ID: "id3", Name: "name3"},
+			}, nil),
+			OutputCheck: testutil.OutputShouldBe("id1: name1\nid2: name2\nid3: name3\n"),
+		},
+		{
+			Name:       "returns an error when the repository layer fails",
+			CmdBuilder: generateBuilder(nil, errUnknownInRepositoryLayer),
+			ErrorCheck: testutil.AnyError(),
+		},
+	}.Run(t)
+}

--- a/internal/repository/atcoder.go
+++ b/internal/repository/atcoder.go
@@ -1,0 +1,7 @@
+package repository
+
+const (
+	AtCoderURL   = "https://atcoder.jp"
+	IncomingPath = "/contests"
+	RecentPath   = "/contests"
+)

--- a/internal/repository/contest_list.go
+++ b/internal/repository/contest_list.go
@@ -1,0 +1,88 @@
+package repository
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/yuchiki/atcoderHelper/pkg/queryablehtml"
+)
+
+var errContestPathCannotBeParsed = errors.New("contest path cannot be parsed")
+
+func getContests(node queryablehtml.QueryableNode, nodeID string) ([]ContestInfo, error) {
+	contestTRs, err := node.
+		GetNodeByID(nodeID).
+		GetChildByTag("div").
+		GetChildByTag("div").
+		GetChildByTag("table").
+		GetChildByTag("tbody").
+		GetChildrenByTag("tr")
+	if err != nil {
+		return nil, err
+	}
+
+	contestInfos := []ContestInfo{}
+
+	for _, tr := range contestTRs {
+		contestInfo, err := trToContestInfo(tr)
+		if err != nil {
+			return nil, err
+		}
+
+		contestInfos = append(contestInfos, contestInfo)
+	}
+
+	return contestInfos, nil
+}
+
+func trToContestInfo(tr queryablehtml.QueryableNode) (ContestInfo, error) {
+	tds, err := tr.GetChildrenByTag("td")
+	if err != nil {
+		return ContestInfo{}, err
+	}
+
+	//nolint: gomnd
+	if len(tds) < 2 {
+		return ContestInfo{}, fmt.Errorf("second td does not exist: %w", queryablehtml.ErrNodeNotFound)
+	}
+
+	link := tds[1].GetChildByTag("a")
+	if link.Err != nil {
+		return ContestInfo{}, err
+	}
+
+	url, err := link.GetAttr("href")
+	if err != nil {
+		return ContestInfo{}, err
+	}
+
+	id, err := getContestID(url)
+	if err != nil {
+		return ContestInfo{}, err
+	}
+
+	name, err := link.GetText()
+	if err != nil {
+		return ContestInfo{}, err
+	}
+
+	return ContestInfo{
+		ID:   id,
+		Name: name,
+	}, nil
+}
+
+func getContestID(contestRelativePath string) (string, error) {
+	each := strings.Split(contestRelativePath, "/")
+
+	//nolint:gomnd
+	if len(each) != 3 {
+		return "", fmt.Errorf(
+			"path '%s' cannot be parsed: %w",
+			contestRelativePath,
+			errContestPathCannotBeParsed)
+	}
+
+	return each[2], nil
+}

--- a/internal/repository/fetch_list_of_contest_util_test.go
+++ b/internal/repository/fetch_list_of_contest_util_test.go
@@ -1,0 +1,69 @@
+package repository
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/yuchiki/atcoderHelper/internal/testutil"
+	"github.com/yuchiki/atcoderHelper/pkg/queryablehtml"
+)
+
+type contestsFetcher func() ([]ContestInfo, error)
+
+func fetchListOfContestTest(t *testing.T, toBeTested contestsFetcher, url string, nodeID string) {
+	t.Helper()
+
+	type testcase struct {
+		name string
+		// nolint:structcheck // なぜかunused判定されてしまうので
+		shouldFetchParsePhaseFail bool
+		html                      string
+		output                    []ContestInfo
+		errorCheck                testutil.ErrorCheck
+	}
+
+	testcases := []testcase{
+		{
+			name: "OK",
+			html: fmt.Sprintf(`<div id="%s">
+					<div><div><table><tbody>
+									<tr><td></td><td><a href="/contest/id1">link1</a></td></tr>
+									<tr><td></td><td><a href="/contest/id2">link2</a></td></tr>
+									<tr><td></td><td><a href="/contest/id3">link3</a></td></tr>
+					</tbody></table></div></div>`, nodeID),
+			output: []ContestInfo{
+				{ID: "id1", Name: "link1"},
+				{ID: "id2", Name: "link2"},
+				{ID: "id3", Name: "link3"},
+			},
+		},
+		{
+			name:                      "return error when failed before parsing",
+			shouldFetchParsePhaseFail: true,
+			errorCheck:                testutil.AnyError(),
+		},
+		{
+			name:       "return error when parsed",
+			errorCheck: testutil.AnyError(),
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			callback := queryablehtml.SetMockFetcher(t, url, testcase.html)
+			defer callback()
+
+			contestInfos, err := toBeTested()
+			if diff := cmp.Diff(testcase.output, contestInfos); diff != "" {
+				t.Error(diff)
+			}
+
+			if testcase.errorCheck == nil {
+				testutil.ShouldNotHaveError()(t, err)
+			} else {
+				testcase.errorCheck(t, err)
+			}
+		})
+	}
+}

--- a/internal/repository/incoming.go
+++ b/internal/repository/incoming.go
@@ -1,19 +1,8 @@
 package repository
 
 import (
-	"errors"
-	"fmt"
-	"strings"
-
 	"github.com/yuchiki/atcoderHelper/pkg/queryablehtml"
 )
-
-const (
-	AtCoderURL   = "https://atcoder.jp"
-	IncomingPath = "/contests"
-)
-
-var errContestPathCannotBeParsed = errors.New("contest path cannot be parsed")
 
 type ContestInfo struct {
 	ID   string
@@ -27,78 +16,5 @@ func FetchIncoming() ([]ContestInfo, error) {
 		return nil, err
 	}
 
-	contestTRs, err := node.
-		GetNodeByID("contest-table-upcoming").
-		GetChildByTag("div").
-		GetChildByTag("div").
-		GetChildByTag("table").
-		GetChildByTag("tbody").
-		GetChildrenByTag("tr")
-	if err != nil {
-		return nil, err
-	}
-
-	contestInfos := []ContestInfo{}
-
-	for _, tr := range contestTRs {
-		contestInfo, err := trToContestInfo(tr)
-		if err != nil {
-			return nil, err
-		}
-
-		contestInfos = append(contestInfos, contestInfo)
-	}
-
-	return contestInfos, nil
-}
-
-func trToContestInfo(tr queryablehtml.QueryableNode) (ContestInfo, error) {
-	tds, err := tr.GetChildrenByTag("td")
-	if err != nil {
-		return ContestInfo{}, err
-	}
-
-	//nolint: gomnd
-	if len(tds) < 2 {
-		return ContestInfo{}, fmt.Errorf("second td does not exist: %w", queryablehtml.ErrNodeNotFound)
-	}
-
-	link := tds[1].GetChildByTag("a")
-	if link.Err != nil {
-		return ContestInfo{}, err
-	}
-
-	url, err := link.GetAttr("href")
-	if err != nil {
-		return ContestInfo{}, err
-	}
-
-	id, err := getContestID(url)
-	if err != nil {
-		return ContestInfo{}, err
-	}
-
-	name, err := link.GetText()
-	if err != nil {
-		return ContestInfo{}, err
-	}
-
-	return ContestInfo{
-		ID:   id,
-		Name: name,
-	}, nil
-}
-
-func getContestID(contestRelativePath string) (string, error) {
-	each := strings.Split(contestRelativePath, "/")
-
-	//nolint:gomnd
-	if len(each) != 3 {
-		return "", fmt.Errorf(
-			"path '%s' cannot be parsed: %w",
-			contestRelativePath,
-			errContestPathCannotBeParsed)
-	}
-
-	return each[2], nil
+	return getContests(node, "contest-table-upcoming")
 }

--- a/internal/repository/incoming_test.go
+++ b/internal/repository/incoming_test.go
@@ -2,63 +2,8 @@ package repository
 
 import (
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
-	"github.com/yuchiki/atcoderHelper/internal/testutil"
-	"github.com/yuchiki/atcoderHelper/pkg/queryablehtml"
 )
 
 func TestFetchIncoming(t *testing.T) {
-	type testcase struct {
-		name string
-		// nolint:structcheck // なぜかunused判定されてしまうので
-		shouldFetchParsePhaseFail bool
-		html                      string
-		output                    []ContestInfo
-		errorCheck                testutil.ErrorCheck
-	}
-
-	testcases := []testcase{
-		{
-			name: "OK",
-			html: `<div id="contest-table-upcoming">
-					<div><div><table><tbody>
-									<tr><td></td><td><a href="/contest/id1">link1</a></td></tr>
-									<tr><td></td><td><a href="/contest/id2">link2</a></td></tr>
-									<tr><td></td><td><a href="/contest/id3">link3</a></td></tr>
-					</tbody></table></div></div>`,
-			output: []ContestInfo{
-				{ID: "id1", Name: "link1"},
-				{ID: "id2", Name: "link2"},
-				{ID: "id3", Name: "link3"},
-			},
-		},
-		{
-			name:                      "return error when failed before parsing",
-			shouldFetchParsePhaseFail: true,
-			errorCheck:                testutil.AnyError(),
-		},
-		{
-			name:       "return error when parsed",
-			errorCheck: testutil.AnyError(),
-		},
-	}
-
-	for _, testcase := range testcases {
-		t.Run(testcase.name, func(t *testing.T) {
-			callback := queryablehtml.SetMockFetcher(t, AtCoderURL+IncomingPath, testcase.html)
-			defer callback()
-
-			contestInfos, err := FetchIncoming()
-			if diff := cmp.Diff(testcase.output, contestInfos); diff != "" {
-				t.Error(diff)
-			}
-
-			if testcase.errorCheck == nil {
-				testutil.ShouldNotHaveError()(t, err)
-			} else {
-				testcase.errorCheck(t, err)
-			}
-		})
-	}
+	fetchListOfContestTest(t, FetchIncoming, AtCoderURL+IncomingPath, "contest-table-upcoming")
 }

--- a/internal/repository/recent.go
+++ b/internal/repository/recent.go
@@ -1,0 +1,15 @@
+package repository
+
+import (
+	"github.com/yuchiki/atcoderHelper/pkg/queryablehtml"
+)
+
+// FetchRecent fetches information of recent contests.
+func FetchRecent() ([]ContestInfo, error) {
+	node, err := queryablehtml.Fetch(AtCoderURL + RecentPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return getContests(node, "contest-table-recent")
+}

--- a/internal/repository/recent_test.go
+++ b/internal/repository/recent_test.go
@@ -1,0 +1,64 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/yuchiki/atcoderHelper/internal/testutil"
+	"github.com/yuchiki/atcoderHelper/pkg/queryablehtml"
+)
+
+func TestFetchRecent(t *testing.T) {
+	type testcase struct {
+		name string
+		// nolint:structcheck // なぜかunused判定されてしまうので
+		shouldFetchParsePhaseFail bool
+		html                      string
+		output                    []ContestInfo
+		errorCheck                testutil.ErrorCheck
+	}
+
+	testcases := []testcase{
+		{
+			name: "OK",
+			html: `<div id="contest-table-recent">
+					<div><div><table><tbody>
+									<tr><td></td><td><a href="/contest/id1">link1</a></td></tr>
+									<tr><td></td><td><a href="/contest/id2">link2</a></td></tr>
+									<tr><td></td><td><a href="/contest/id3">link3</a></td></tr>
+					</tbody></table></div></div>`,
+			output: []ContestInfo{
+				{ID: "id1", Name: "link1"},
+				{ID: "id2", Name: "link2"},
+				{ID: "id3", Name: "link3"},
+			},
+		},
+		{
+			name:                      "return error when failed before parsing",
+			shouldFetchParsePhaseFail: true,
+			errorCheck:                testutil.AnyError(),
+		},
+		{
+			name:       "return error when parsed",
+			errorCheck: testutil.AnyError(),
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			callback := queryablehtml.SetMockFetcher(t, AtCoderURL+IncomingPath, testcase.html)
+			defer callback()
+
+			contestInfos, err := FetchRecent()
+			if diff := cmp.Diff(testcase.output, contestInfos); diff != "" {
+				t.Error(diff)
+			}
+
+			if testcase.errorCheck == nil {
+				testutil.ShouldNotHaveError()(t, err)
+			} else {
+				testcase.errorCheck(t, err)
+			}
+		})
+	}
+}

--- a/internal/repository/recent_test.go
+++ b/internal/repository/recent_test.go
@@ -2,63 +2,8 @@ package repository
 
 import (
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
-	"github.com/yuchiki/atcoderHelper/internal/testutil"
-	"github.com/yuchiki/atcoderHelper/pkg/queryablehtml"
 )
 
 func TestFetchRecent(t *testing.T) {
-	type testcase struct {
-		name string
-		// nolint:structcheck // なぜかunused判定されてしまうので
-		shouldFetchParsePhaseFail bool
-		html                      string
-		output                    []ContestInfo
-		errorCheck                testutil.ErrorCheck
-	}
-
-	testcases := []testcase{
-		{
-			name: "OK",
-			html: `<div id="contest-table-recent">
-					<div><div><table><tbody>
-									<tr><td></td><td><a href="/contest/id1">link1</a></td></tr>
-									<tr><td></td><td><a href="/contest/id2">link2</a></td></tr>
-									<tr><td></td><td><a href="/contest/id3">link3</a></td></tr>
-					</tbody></table></div></div>`,
-			output: []ContestInfo{
-				{ID: "id1", Name: "link1"},
-				{ID: "id2", Name: "link2"},
-				{ID: "id3", Name: "link3"},
-			},
-		},
-		{
-			name:                      "return error when failed before parsing",
-			shouldFetchParsePhaseFail: true,
-			errorCheck:                testutil.AnyError(),
-		},
-		{
-			name:       "return error when parsed",
-			errorCheck: testutil.AnyError(),
-		},
-	}
-
-	for _, testcase := range testcases {
-		t.Run(testcase.name, func(t *testing.T) {
-			callback := queryablehtml.SetMockFetcher(t, AtCoderURL+IncomingPath, testcase.html)
-			defer callback()
-
-			contestInfos, err := FetchRecent()
-			if diff := cmp.Diff(testcase.output, contestInfos); diff != "" {
-				t.Error(diff)
-			}
-
-			if testcase.errorCheck == nil {
-				testutil.ShouldNotHaveError()(t, err)
-			} else {
-				testcase.errorCheck(t, err)
-			}
-		})
-	}
+	fetchListOfContestTest(t, FetchRecent, AtCoderURL+RecentPath, "contest-table-recent")
 }


### PR DESCRIPTION
# Description

What the title says.
`Recent` subcommand fetches recent contests from the website.

Close #79 

## Type of Change

- [x] New Feature

# How This has been Tested

- [x] passed the CI lint.
- [x] passed the CI test.

# Checklist

- [x] The code is linted. (automatically)
- [x] The code is unit-tested. (automatically)
<!-- - [ ] The code is integrated-tested. (not yet implemented.) -->
- [x] Added needed tests. (or it does not need any additional tests.)
- [x] made corresponding changes to the documentation. (or it does not need any doc's changes.)
