### PR TITLE
Reform testcases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bin
 /dist
+.vscode

--- a/internal/cmd/ach/contest/create/create.go
+++ b/internal/cmd/ach/contest/create/create.go
@@ -14,6 +14,8 @@ import (
 
 var openEditor = new(bool)
 
+const numSampleCases = 5
+
 // NewContestCreateCmd returns a new contest create command.
 func NewContestCreateCmd() *cobra.Command {
 	useDefaultTemplate := new(bool)
@@ -112,7 +114,7 @@ func initializeTaskDirectory(absTemplateDir, contestName, taskName string) error
 
 	sampleDirName := path.Join(taskDirName, "sampleCases")
 
-	err = createSampleCases(sampleDirName, 5) //nolint:gomnd
+	err = createSampleCases(sampleDirName, numSampleCases)
 	if err != nil {
 		return err
 	}

--- a/pkg/testcase/status.go
+++ b/pkg/testcase/status.go
@@ -1,0 +1,19 @@
+package testcase
+
+type Status int
+
+const (
+	Pass Status = iota
+	NotPassed
+)
+
+func (s Status) String() string {
+	switch s {
+	case Pass:
+		return "pass"
+	case NotPassed:
+		return "not passed"
+	default:
+		return "unknown status"
+	}
+}

--- a/pkg/testcase/status.go
+++ b/pkg/testcase/status.go
@@ -3,12 +3,15 @@ package testcase
 type Status int
 
 const (
-	Pass Status = iota
+	Untested Status = iota
+	Pass
 	NotPassed
 )
 
 func (s Status) String() string {
 	switch s {
+	case Untested:
+		return "untested"
 	case Pass:
 		return "pass"
 	case NotPassed:

--- a/pkg/testcase/testcase.go
+++ b/pkg/testcase/testcase.go
@@ -1,0 +1,23 @@
+package testcase
+
+type Testcase struct {
+	Fetched  bool
+	Input    string
+	Expected string
+	Actual   string
+	Status   Status
+}
+
+func (t *Testcase) Check(actual string) Status {
+	var status Status
+	if t.Expected == actual {
+		status = Pass
+	} else {
+		status = NotPassed
+	}
+
+	t.Actual = actual
+	t.Status = status
+
+	return status
+}

--- a/pkg/testcase/testcase_test.go
+++ b/pkg/testcase/testcase_test.go
@@ -1,0 +1,48 @@
+package testcase
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestTestcase_Check(t *testing.T) {
+	testcases := []struct {
+		name     string
+		expected string
+		actual   string
+		status   Status
+	}{
+		{
+			name:     "Pass when no diff",
+			expected: "foo",
+			actual:   "foo",
+			status:   Pass,
+		},
+		{
+			name:     "NotPassed with diff",
+			expected: "foo",
+			actual:   "bar",
+			status:   NotPassed,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Helper()
+
+			taskTestcase := Testcase{
+				Expected: testcase.expected,
+			}
+
+			_ = taskTestcase.Check(testcase.actual)
+
+			if diff := cmp.Diff(testcase.actual, taskTestcase.Actual); diff != "" {
+				t.Error(diff)
+			}
+			if taskTestcase.Status != testcase.status {
+				t.Errorf("expected %v, but actual %v", testcase.status, taskTestcase.Status)
+			}
+		})
+	}
+}

--- a/pkg/testcase/testcases.go
+++ b/pkg/testcase/testcases.go
@@ -45,7 +45,7 @@ func (ts Testcases) MergeWithFetched(fetched Testcases) Testcases {
 		}
 	}
 
-	joinedTestcases := append(fetched.Testcases, unfetchedTestcases...)
+	joinedTestcases := append(fetched.Testcases, unfetchedTestcases...) //nolint:gocritic // this is intended.
 
 	return NewTestcases(joinedTestcases)
 }

--- a/pkg/testcase/testcases.go
+++ b/pkg/testcase/testcases.go
@@ -33,3 +33,19 @@ func NewTestCases(bareTestcases []Testcase) Testcases {
 		},
 	}
 }
+
+func (ts Testcases) MergeWithFetched(fetched Testcases) Testcases {
+	// fetched の validationは省く
+
+	unfetchedTestcases := []Testcase{}
+
+	for _, testcase := range ts.Testcases {
+		if !testcase.Fetched {
+			unfetchedTestcases = append(unfetchedTestcases, testcase)
+		}
+	}
+
+	joinedTestcases := append(fetched.Testcases, unfetchedTestcases...)
+
+	return NewTestCases(joinedTestcases)
+}

--- a/pkg/testcase/testcases.go
+++ b/pkg/testcase/testcases.go
@@ -1,0 +1,10 @@
+package testcase
+
+type Testcases struct {
+	Testcases []Testcase
+	Summary   Summary
+}
+
+type Summary struct {
+	Status Status
+}

--- a/pkg/testcase/testcases.go
+++ b/pkg/testcase/testcases.go
@@ -8,3 +8,28 @@ type Testcases struct {
 type Summary struct {
 	Status Status
 }
+
+func NewTestCases(bareTestcases []Testcase) Testcases {
+	allPass := func() bool {
+		for _, testcase := range bareTestcases {
+			if testcase.Status != Pass {
+				return false
+			}
+		}
+		return true
+	}
+
+	var status Status
+	if allPass() {
+		status = Pass
+	} else {
+		status = NotPassed
+	}
+
+	return Testcases{
+		Testcases: bareTestcases,
+		Summary: Summary{
+			Status: status,
+		},
+	}
+}

--- a/pkg/testcase/testcases.go
+++ b/pkg/testcase/testcases.go
@@ -16,6 +16,7 @@ func NewTestCases(bareTestcases []Testcase) Testcases {
 				return false
 			}
 		}
+
 		return true
 	}
 
@@ -36,7 +37,6 @@ func NewTestCases(bareTestcases []Testcase) Testcases {
 
 func (ts Testcases) MergeWithFetched(fetched Testcases) Testcases {
 	// fetched の validationは省く
-
 	unfetchedTestcases := []Testcase{}
 
 	for _, testcase := range ts.Testcases {

--- a/pkg/testcase/testcases.go
+++ b/pkg/testcase/testcases.go
@@ -9,7 +9,7 @@ type Summary struct {
 	Status Status
 }
 
-func NewTestCases(bareTestcases []Testcase) Testcases {
+func NewTestcases(bareTestcases []Testcase) Testcases {
 	allPass := func() bool {
 		for _, testcase := range bareTestcases {
 			if testcase.Status != Pass {
@@ -47,5 +47,5 @@ func (ts Testcases) MergeWithFetched(fetched Testcases) Testcases {
 
 	joinedTestcases := append(fetched.Testcases, unfetchedTestcases...)
 
-	return NewTestCases(joinedTestcases)
+	return NewTestcases(joinedTestcases)
 }

--- a/pkg/testcase/testcases_test.go
+++ b/pkg/testcase/testcases_test.go
@@ -1,0 +1,58 @@
+package testcase
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewTestcases(t *testing.T) {
+	testcases := []struct {
+		name          string
+		bareTestcases []Testcase
+		testcases     Testcases
+	}{
+		{
+			name: "all cases are passing",
+			bareTestcases: []Testcase{
+				{Status: Pass},
+				{Status: Pass},
+				{Status: Pass},
+			},
+			testcases: Testcases{
+				Testcases: []Testcase{
+					{Status: Pass},
+					{Status: Pass},
+					{Status: Pass},
+				},
+				Summary: Summary{Status: Pass},
+			},
+		},
+		{
+			name: "there exists a case not passing",
+			bareTestcases: []Testcase{
+				{Status: Pass},
+				{Status: Pass},
+				{Status: NotPassed},
+			},
+			testcases: Testcases{
+				Testcases: []Testcase{
+					{Status: Pass},
+					{Status: Pass},
+					{Status: NotPassed},
+				},
+				Summary: Summary{Status: NotPassed},
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			taskTestcases := NewTestcases(testcase.bareTestcases)
+
+			if diff := cmp.Diff(testcase.testcases, taskTestcases); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Changes the mechanism for managing test cases.

before: each input and output of a single test case is a file.
after: a suit of test cases are in a single yaml file.

Close #87


Associated #88 #86

## Type of Change

- [x] Refactoring

# How This has been Tested

- [x] passed the CI lint.
- [x] passed the CI test.

# Checklist

- [x] The code is linted. (automatically)
- [x] The code is unit-tested. (automatically)
